### PR TITLE
Fixed crash when Dlls missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,14 @@
 C2-PRINTF is a small utility that lets you do printf()-style debugging over a C2 debugger connection, for use with the Silicon Labs EFM8 and C8051F microcontrollers.
 
 Full write up available on my blog:
-https://jaycarlson.net/2017/07/16/printf-style-trace-messages-using-c2/
+[https://jaycarlson.net/2017/07/16/printf-style-trace-messages-using-c2/](https://jaycarlson.net/2017/07/16/printf-style-trace-messages-using-c2/)
+
+If you build the WPF application you will need to ensure that the following DLLs are in the same folder as the c2-printf executable. 
+(i.e. ..\c2-printf\bin\Debug)
+
+- libgcc_s_dw2-1.dll
+- libstdc++-6.dll
+- slab8051.dll
+- slabhiddevice.dll
+
+These can be found in the C:\SiliconLabs\SimplicityStudio\v3\common\tcf and C:\SiliconLabs\SimplicityStudio\v3\common\tcf\plugins folder.

--- a/c2-printf/C2Scanner.cs
+++ b/c2-printf/C2Scanner.cs
@@ -22,7 +22,17 @@ namespace c2_printf
         public C2Scanner()
         {
             Debuggers.CollectionChanged += Debuggers_CollectionChanged;
-            Scan();
+            try
+            {
+                Scan();
+            }
+            catch (Exception e)
+            {
+                // display a message about the missing DLLs
+                String message = e.Message;
+                message += "\n\nMake sure the following DLLs exist in the program folder:\n\n\tlibgcc_s_dw2-1.dll\n\tlibstdc++-6.dll\n\tslab8051.dll\n\tslabhiddevice.dll\n";
+                MessageBoxResult result = MessageBox.Show(message, "Dll(s) Missing?", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+            }
         }
 
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
Added code to display a simple message box if the app throws an exception when first accessing the slab8051.dll